### PR TITLE
docs: 📝 update project name and Go version requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# nomos-provider-file
+# Nomos File Provider
 
 Reference implementation of an external Nomos provider for file system access.
 
@@ -105,7 +105,7 @@ The provider accepts the following configuration in the `Init` RPC call:
 
 ### Prerequisites
 
-- Go 1.24.4 or later
+- Go 1.25+ or later
 - Protocol Buffers compiler (for regenerating proto stubs)
 - Local clone of the Nomos repository (for now, until modules are published)
 


### PR DESCRIPTION
This pull request updates the documentation for the Nomos File Provider to improve clarity and ensure accuracy regarding prerequisites.

Documentation improvements:

* Updated the project title in `README.md` for better clarity and consistency.
* Revised the Go version prerequisite from "Go 1.24.4 or later" to "Go 1.25+ or later" in `README.md` to reflect the required version.