### PR TITLE
Add CODEOWNERS file to define repository ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# CODEOWNERS file
+# This file defines code ownership for the repository.
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+#
+# More details: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for everything in the repo
+# Unless a later match takes precedence, @pewpewpotato will be requested for review
+* @pewpewpotato
+
+# You can add more specific rules if needed in the future, for example:
+# /docs/ @pewpewpotato @other-user
+# *.md @pewpewpotato @doc-team

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,9 @@ Thumbs.db
 # Temporary files
 tmp/
 temp/
+
+# AI agent and specification files
+.github/agents/
+.github/prompts/
+.specify/
+specs/


### PR DESCRIPTION
This pull request introduces a `.github/CODEOWNERS` file to the repository, establishing default code ownership and providing guidance for future customization.

Repository ownership:

* Added a `.github/CODEOWNERS` file that assigns `@pewpewpotato` as the default owner for all files in the repository, ensuring they are requested for review on all changes unless more specific rules are added later.
* Included comments and examples in the `CODEOWNERS` file to help future contributors add more specific ownership rules as needed.