### PR TITLE
Release v0.2.1: Fix Fetch path resolution for single instance mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.1] - 2026-01-14
+## [0.2.1] - 2026-01-14
+
+### Fixed
+- Fetch method now automatically detects single vs multi-instance mode for path resolution
+- Single instance mode: path starts with filename directly (e.g., `["prod", "database", "name"]`)
+- Multi-instance mode: path must include alias first (e.g., `["configs", "prod", "database", "name"]`)
+- Fixed "provider instance not found" error when using single provider with file references
+
+### Note
+- This fix ensures backward compatibility with Nomos CLI's reference resolution behavior
+
+## [0.2.0] - 2026-01-14
 
 ### Added
 - Multiple provider instance support - enables users to work with multiple configuration directories simultaneously
@@ -57,6 +68,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - README with usage and installation instructions2...HEAD
 [0.1.2]: https://github.com/autonomous-bits/nomos-provider-file/compare/v0.1.1...v0.1.2
 
-[Unreleased]: https://github.com/autonomous-bits/nomos-provider-file/compare/v0.1.1...HEAD
-[0.1.1]: https://github.com/autonomous-bits/nomos-provider-file/compare/v0.1.0...v0.1.1
+[Unreleased]: https://github.com/autonomous-bits/nomos-provider-file/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/autonomous-bits/nomos-provider-file/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/autonomous-bits/nomos-provider-file/compare/v0.1.2...v0.2.0
+[0.1.2]: https://github.com/autonomous-bits/nomos-provider-file/compare/v0.1.1...v0.1.2
 [0.1.0]: https://github.com/autonomous-bits/nomos-provider-file/releases/tag/v0.1.0

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version      = "0.1.0"
+	version      = "0.2.1"
 	providerType = "file"
 )
 


### PR DESCRIPTION
This pull request updates the project to version 0.2.1, focusing on improving the provider's fetch method to better handle both single and multi-instance configurations, and fixing path resolution issues. It also ensures backward compatibility with the Nomos CLI's reference resolution behavior.

Versioning and release updates:

* Bumped the provider version from `0.1.0` to `0.2.1` in `cmd/provider/main.go` and updated the changelog to reflect the new release and comparison links. [[1]](diffhunk://#diff-36b6d20eb5aea66cf39f8d94111bd96513626ef7f61459f0d9e8e9507ded1d17L17-R17) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL10-R21) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL60-R74)

Bug fixes and improvements:

* Fixed the fetch method to automatically detect and correctly resolve paths for both single and multi-instance modes, preventing "provider instance not found" errors and aligning with Nomos CLI expectations.