### PR TITLE
fix: Update version constant to 0.3.6 and document the change in the …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.6] - 2026-02-17
+
+### Fixed
+- Updated version constant to match actual release version (was incorrectly showing v0.2.1)
+
 ## [0.3.5] - 2026-02-17
 
 ### Changed
@@ -113,10 +118,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test suite with >80% coverage
 - CI/CD pipeline with GitHub Actions
 - GoReleaser configuration for automated releases
-- README with usage and installation instructions2...HEAD
-[0.1.2]: https://github.com/autonomous-bits/nomos-provider-file/compare/v0.1.1...v0.1.2
+- README with usage and installation instructions
 
-[Unreleased]: https://github.com/autonomous-bits/nomos-provider-file/compare/v0.3.5...HEAD
+[Unreleased]: https://github.com/autonomous-bits/nomos-provider-file/compare/v0.3.6...HEAD
+[0.3.6]: https://github.com/autonomous-bits/nomos-provider-file/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/autonomous-bits/nomos-provider-file/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/autonomous-bits/nomos-provider-file/compare/v0.3.2...v0.3.4
 [0.3.2]: https://github.com/autonomous-bits/nomos-provider-file/compare/v0.3.1...v0.3.2
@@ -125,4 +130,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.2.1]: https://github.com/autonomous-bits/nomos-provider-file/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/autonomous-bits/nomos-provider-file/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/autonomous-bits/nomos-provider-file/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/autonomous-bits/nomos-provider-file/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/autonomous-bits/nomos-provider-file/releases/tag/v0.1.0

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version      = "0.2.1"
+	version      = "0.3.6"
 	providerType = "file"
 )
 


### PR DESCRIPTION
This pull request updates the project to version 0.3.6, correcting the version constant and updating the changelog to reflect the new release. The main focus is on ensuring version consistency and maintaining accurate release documentation.

Release and versioning updates:

* Updated the `version` constant in `cmd/provider/main.go` to `0.3.6` to match the actual release version (previously incorrectly set to `v0.2.1`).
* Added a new `0.3.6` release entry to `CHANGELOG.md`, listing the version constant fix under "Fixed".
* Updated the `[Unreleased]` and `[0.3.6]` comparison links in `CHANGELOG.md` to point to the correct release tags.
* Added a missing comparison link for version `0.1.1` in `CHANGELOG.md` for completeness.…changelog.